### PR TITLE
Rename CRC variable to avoid conflict with CMSIS definition on STM32 platforms

### DIFF
--- a/src/SparkFun_SGP40_Arduino_Library.cpp
+++ b/src/SparkFun_SGP40_Arduino_Library.cpp
@@ -347,11 +347,11 @@ uint8_t SGP40::_CRC8(uint16_t data)
 //Generates CRC8 for SGP40 from lookup table
 uint8_t SGP40::_CRC8(uint16_t data)
 {
-  uint8_t CRC = 0xFF; //inital value
-  CRC ^= (uint8_t)(data >> 8); //start with MSB
-  CRC = _CRC8LookupTable[CRC >> 4][CRC & 0xF]; //look up table [MSnibble][LSnibble]
-  CRC ^= (uint8_t)data; //use LSB
-  CRC = _CRC8LookupTable[CRC >> 4][CRC & 0xF]; //look up table [MSnibble][LSnibble]
-  return CRC;
+  uint8_t crc = 0xFF; //inital value
+  crc ^= (uint8_t)(data >> 8); //start with MSB
+  crc = _CRC8LookupTable[crc >> 4][crc & 0xF]; //look up table [MSnibble][LSnibble]
+  crc ^= (uint8_t)data; //use LSB
+  crc = _CRC8LookupTable[crc >> 4][crc & 0xF]; //look up table [MSnibble][LSnibble]
+  return crc;
 }
 #endif


### PR DESCRIPTION
In STM32 CMSIS files (on [Arduino Portenta H7](https://github.com/arduino/ArduinoCore-mbed/blob/master/cores/arduino/mbed/targets/TARGET_STM/TARGET_STM32H7/STM32Cube_FW/CMSIS/stm32h747xx.h) or [STM32duino](https://github.com/stm32duino/Arduino_Core_STM32/tree/main/system/Drivers/CMSIS/Device/ST)), the `CRC` symbol is already defined with this line:
```
#define CRC                 ((CRC_TypeDef *) CRC_BASE)
```

This prevents this library to build because the method `_CRC8` uses the same symbol for a local variable.

This PR rename the variable to lowercase to avoid the build issue.

Build error:
```
In file included from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/system/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h7xx.h:117,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/stm32/stm32_def.h:42,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/stm32/clock.h:43,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/wiring_time.h:23,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/wiring.h:38,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/Arduino.h:36,
                 from /home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.h:47,
                 from /home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:44:
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp: In member function 'uint8_t SGP40::_CRC8(uint16_t)':
/home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/system/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h743xx.h:2430:54: error: cast from 'CRC_TypeDef*' to 'uint8_t' {aka 'unsigned char'} loses precision [-fpermissive]
 2430 | #define CRC                 ((CRC_TypeDef *) CRC_BASE)
      |                                                      ^
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:350:11: note: in expansion of macro 'CRC'
  350 |   uint8_t CRC = 0xFF; //inital value
      |           ^~~
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:350:17: error: lvalue required as left operand of assignment
  350 |   uint8_t CRC = 0xFF; //inital value
      |                 ^~~~
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:351:7: error: invalid operands of types 'CRC_TypeDef*' and 'uint8_t' {aka 'unsigned char'} to binary 'operator^'
  351 |   CRC ^= (uint8_t)(data >> 8); //start with MSB
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:351:29: error:   in evaluation of 'operator^=(struct CRC_TypeDef*, uint8_t {aka unsigned char})'
  351 |   CRC ^= (uint8_t)(data >> 8); //start with MSB
      |                             ^
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:352:30: error: invalid operands of types 'CRC_TypeDef*' and 'int' to binary 'operator>>'
  352 |   CRC = _CRC8LookupTable[CRC >> 4][CRC & 0xF]; //look up table [MSnibble][LSnibble]
      |                              ^~ ~
      |                                 |
      |                                 int
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:352:40: error: invalid operands of types 'CRC_TypeDef*' and 'int' to binary 'operator&'
  352 |   CRC = _CRC8LookupTable[CRC >> 4][CRC & 0xF]; //look up table [MSnibble][LSnibble]
      |                                        ^ ~~~
      |                                          |
      |                                          int
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:353:7: error: invalid operands of types 'CRC_TypeDef*' and 'uint8_t' {aka 'unsigned char'} to binary 'operator^'
  353 |   CRC ^= (uint8_t)data; //use LSB
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:353:19: error:   in evaluation of 'operator^=(struct CRC_TypeDef*, uint8_t {aka unsigned char})'
  353 |   CRC ^= (uint8_t)data; //use LSB
      |                   ^~~~
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:354:30: error: invalid operands of types 'CRC_TypeDef*' and 'int' to binary 'operator>>'
  354 |   CRC = _CRC8LookupTable[CRC >> 4][CRC & 0xF]; //look up table [MSnibble][LSnibble]
      |                              ^~ ~
      |                                 |
      |                                 int
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:354:40: error: invalid operands of types 'CRC_TypeDef*' and 'int' to binary 'operator&'
  354 |   CRC = _CRC8LookupTable[CRC >> 4][CRC & 0xF]; //look up table [MSnibble][LSnibble]
      |                                        ^ ~~~
      |                                          |
      |                                          int
In file included from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/system/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h7xx.h:117,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/stm32/stm32_def.h:42,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/stm32/clock.h:43,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/wiring_time.h:23,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/wiring.h:38,
                 from /home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/cores/arduino/Arduino.h:36,
                 from /home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.h:47,
                 from /home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:44:
/home/romain/.arduino15/packages/STM32/hardware/stm32/1.9.0/system/Drivers/CMSIS/Device/ST/STM32H7xx/Include/stm32h743xx.h:2430:30: error: invalid conversion from 'CRC_TypeDef*' to 'uint8_t' {aka 'unsigned char'} [-fpermissive]
 2430 | #define CRC                 ((CRC_TypeDef *) CRC_BASE)
      |                             ~^~~~~~~~~~~~~~~~~~~~~~~~~
      |                              |
      |                              CRC_TypeDef*
/home/romain/Arduino/libraries/SparkFun_SGP40_Arduino_Library/src/SparkFun_SGP40_Arduino_Library.cpp:355:10: note: in expansion of macro 'CRC'
  355 |   return CRC;
      |          ^~~

Compilation error: exit status 1
```

Reported here: https://forum.arduino.cc/t/ambiguous-reference-to-stream/985899/5